### PR TITLE
Add a target for the US States without county data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -659,3 +659,13 @@ topo/us-10m.json: topo/us-states-10m.json
 		--out-object=land \
 		--no-key \
 		-- topo/us-states-10m.json
+
+topo/us-states-no-counties-10m.json: shp/us/states.shp
+	mkdir -p $(dir $@)
+	node_modules/.bin/topojson \
+		-o $@ \
+		--no-pre-quantization \
+		--post-quantization=1e6 \
+		--simplify=7e-7 \
+		--id-property=+STATE_FIPS \
+		-- $<

--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ The U.S. county, state and nation boundaries simplified at 1:10,000,000 scale.
 The districts of the 113th U.S. Congress simplified at 1:10,000,000 scale.
 
 There are partial targets defined for a large number of other boundary areas and geographic features. However, you’ll have to figure these out on your own for now. Sorry!
+
+<b>topo/us-states-no-counties-10m.json</b>
+
+The same as us-10m, but without county boundaries.


### PR DESCRIPTION
For my current project, I don't need counties and I just wanted a smaller topojson file of the US. This pull request adds a makefile target for such a file and adds it to the README.

* Question: I don't think I need a topojson-merge step (I tried, and it didn't prune anything). Is that accurate?
* I chose the simplest, most descriptive name I could think of, but I'm not overwhelmingly happy with it. Would be happy to change the target's name.