### PR TITLE
Add 10m ungrouped make target from individual state shape files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -616,6 +616,16 @@ png/%.png: shp/%.shp bin/rasterize
 	node --max_old_space_size=8192 bin/rasterize $< $@
 	optipng $@
 
+topo/%/counties-10m-ungrouped.json: shp/%/counties.shp
+	mkdir -p $(dir $@)
+	node_modules/.bin/topojson \
+		-o $@ \
+		--no-pre-quantization \
+		--post-quantization=1e6 \
+		--simplify=7e-7 \
+		--id-property=+FIPS \
+		-- $<
+
 topo/us-congress-10m-ungrouped.json: shp/us/congress-ungrouped.shp
 	mkdir -p $(dir $@)
 	node_modules/.bin/topojson \


### PR DESCRIPTION
This was removed at some point in the past, but it seems like a useful one to have in there to allow generating individual state topojson files. If there's a preferred naming convention, let me know and I'd be happy to go with whatever works better.